### PR TITLE
ui(plan-badge): switch Plan label to solid emerald across header/home…

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -148,7 +148,7 @@ export default function ChatHeader({
 						<Popover>
 							<PopoverTrigger asChild>
 								<button className='capitalize border border-border rounded-xl flex items-center gap-2 px-4 py-2 font-semibold text-foreground cursor-pointer hover:bg-accent transition-all shadow-sm hover:shadow-md bg-card'>
-									<span className='text-xs bg-gradient-to-r from-pink-500 to-purple-500 text-white px-2.5 py-1 rounded-full font-bold'>
+									<span className='text-xs bg-emerald-500 text-white px-2.5 py-1 rounded-full font-bold'>
 										Plan
 									</span>
 									<span className='text-sm'>{getPlanName(plan)}</span>

--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -101,7 +101,7 @@ export default function ChatSidebar({
 							<Popover>
 								<PopoverTrigger asChild>
 									<button className='w-full capitalize border border-border rounded-xl flex items-center gap-2 px-3 py-2 font-semibold text-foreground cursor-pointer hover:bg-accent transition-all shadow-sm hover:shadow-md bg-card text-xs sm:text-sm'>
-										<span className='text-xs bg-gradient-to-r from-pink-500 to-purple-500 text-white px-2 py-0.5 rounded-full font-bold'>
+										<span className='text-xs bg-emerald-500 text-white px-2 py-0.5 rounded-full font-bold'>
 											Plan
 										</span>
 										<span className='flex-1 text-left truncate'>

--- a/src/components/HomeSidebar.tsx
+++ b/src/components/HomeSidebar.tsx
@@ -172,7 +172,7 @@ export default function HomeSidebar({
 						<Popover>
 							<PopoverTrigger asChild>
 								<button className='w-full capitalize border border-border rounded-xl flex items-center gap-2 px-4 py-2.5 font-semibold text-foreground cursor-pointer hover:bg-accent transition-all shadow-sm hover:shadow-md bg-card'>
-									<span className='text-xs bg-gradient-to-r from-pink-500 to-purple-500 text-white px-2.5 py-1 rounded-full font-bold'>
+									<span className='text-xs bg-emerald-500 text-white px-2.5 py-1 rounded-full font-bold'>
 										Plan
 									</span>
 									<span className='text-sm flex-1 text-left'>


### PR DESCRIPTION
…/chat sidebars